### PR TITLE
FernoConfiguration.tokenExpirationDate typo fixed

### DIFF
--- a/Sources/Ferno/FernoClient.swift
+++ b/Sources/Ferno/FernoClient.swift
@@ -123,7 +123,7 @@ extension FernoAPIClient {
         
         if let cachedToken = lock.withLock({
             if let accessToken = configuration.accessToken,
-               let tokenExpriationDate = configuration.tokenExpriationDate,
+               let tokenExpriationDate = configuration.tokenExpirationDate,
                Date().timeIntervalSince(tokenExpriationDate) > 30*60 { // should be valid for 1 hour
                 return accessToken
             } else {
@@ -151,7 +151,7 @@ extension FernoAPIClient {
         let res = try await client.send(req).content.decode(OAuthResponse.self)
         lock.withLockVoid {
             self.configuration.accessToken = res.access_token
-            self.configuration.tokenExpriationDate = Date().addingTimeInterval(TimeInterval(res.expires_in))
+            self.configuration.tokenExpirationDate = Date().addingTimeInterval(TimeInterval(res.expires_in))
         }
         self.configuration.logger.debug("Access token received")
         return res.access_token

--- a/Sources/Ferno/FernoConfiguration.swift
+++ b/Sources/Ferno/FernoConfiguration.swift
@@ -13,21 +13,21 @@ public struct FernoConfiguration {
     public let email: String
     public let privateKey: String
     public var accessToken: String?
-    public var tokenExpriationDate: Date?
+    public var tokenExpirationDate: Date?
 
     public init(
         basePath: String,
         email: String,
         privateKey: String,
         accessToken: String? = nil,
-        tokenExpriationDate: Date? = nil,
+        tokenExpirationDate: Date? = nil,
         logger: Logger = .init(label: "codes.vapor.ferno")
     ) {
         self.basePath = basePath
         self.email = email
         self.privateKey = privateKey
         self.accessToken = accessToken
-        self.tokenExpriationDate = tokenExpriationDate
+        self.tokenExpirationDate = tokenExpirationDate
         self.logger = logger
     }
 }


### PR DESCRIPTION
## What changed

- Typo error: `FernoConfiguration.tokenExpriationDate` to `FernoConfiguration.tokenExpirationDate`

✅ Tests passed ✅

![Screenshot 2023-10-05 at 9 51 34 PM](https://github.com/vapor-community/ferno/assets/30416292/ad66ba33-4e9d-458b-bdd1-68641fdee594)
